### PR TITLE
Don't build tests for DeviceAccess

### DIFF
--- a/recipes-deviceaccess/deviceaccess/deviceaccess_03.11.00.bb
+++ b/recipes-deviceaccess/deviceaccess/deviceaccess_03.11.00.bb
@@ -19,4 +19,4 @@ DEPENDS = "glib-2.0 libxml++ boost cppext exprtk exprtk"
 inherit cmake pkgconfig
 
 # Specify any options you want to pass to cmake using EXTRA_OECMAKE:
-EXTRA_OECMAKE = ""
+EXTRA_OECMAKE = "-DBUILD_TESTS=OFF"


### PR DESCRIPTION
I see there is a wip branch already that selectively enables or disables the tests. However I had to disable them in the zeus branch or else DeviceAccess wouldn't build on my machine. Probably the compiler runs out of memory (see below). I guess I could reduce the load with `PARALLEL_MAKE` in `local.conf` but that would slow down the entire Yocto build which is also not ideal.

```
...
/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot-native/usr/bin/aarch64-xilinx-linux/aarch64-xilinx-linux-g++  -DBOOST_ALL_NO_LIB -DBOOST_CHRONO_DYN_LINK -DBOOST_FILES
YSTEM_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DBOOST_THREAD_DYN_LINK -DCHIMERATK_HAVE_PCIE_BACKEND -DCHIMERATK_HAVE_UIO_BACKEND -DCHIMERATK_HAVE_XDMA_BACKEND -DChimeraTK_DeviceAccess_EXPORTS -Igenerated_include -I/mnt/yocto/petra_motion_control
/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/include -I/mnt/yocto/p
etra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/exception/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/util/include -I/
mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/fileparsers/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/dev
ice_backends/NumericAddressedBackend/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/DummyBackend/include -I/mnt/yocto/petra_motion_control/prj/yocto/bui
ld/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/LogicalNameMapping/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/Subdevic
e/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/SharedDummy/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/dev
iceaccess/03.11.00-r0/git/device_backends/Rebot/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/mmio/include -I/mnt/yocto/petra_motion_control/prj/yocto/
build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/pcie/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/xdma/include -I/mnt
/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git/device_backends/uio/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/re
cipe-sysroot/usr/include/libxml++-2.6 -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot/usr/lib/libxml++-2.6/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/t
mp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot/usr/include/libxml2 -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot/usr/include/glibmm-2.4 -I/mnt
/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot/usr/lib/glibmm-2.4/include -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.1
1.00-r0/recipe-sysroot/usr/include/glib-2.0 -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot/usr/lib/glib-2.0/include -I/mnt/yocto/petra_motion_control/prj/yocto/build
/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot/usr/include/sigc++-2.0 -I/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot/usr/lib/sigc++-2.0/inclu
de -march=armv8-a+crc -mtune=cortex-a72.cortex-a53 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/d
eviceaccess/03.11.00-r0/recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0=/usr/src/debug/deviceaccess/03.1
1.00-r0                      -fdebug-prefix-map=/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0=/usr/src/debug/deviceaccess/03.11.00-r0                      -fdebug-prefix-map=/mnt/yo
cto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot=                      -fdebug-prefix-map=/mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceac
cess/03.11.00-r0/recipe-sysroot-native=  -fvisibility-inlines-hidden  -march=armv8-a+crc -mtune=cortex-a72.cortex-a53 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/mnt/yocto/p
etra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/recipe-sysroot -std=c++17  -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR -std=c++17 -Wall -Wextra -Wshadow -pedantic -Wuninitialized -O2 -g -DNDEBUG -O3 
-g -fPIC   -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR -std=c++17 -MD -MT CMakeFiles/ChimeraTK-DeviceAccess.dir/device_backends/LogicalNameMapping/src/LNMMathPlugin.cc.o -MF CMakeFiles/ChimeraTK-DeviceAccess.dir/device_backends/LogicalNameMap
ping/src/LNMMathPlugin.cc.o.d -o CMakeFiles/ChimeraTK-DeviceAccess.dir/device_backends/LogicalNameMapping/src/LNMMathPlugin.cc.o -c /mnt/yocto/petra_motion_control/prj/yocto/build/tmp/work/aarch64-xilinx-linux/deviceaccess/03.11.00-r0/git
/device_backends/LogicalNameMapping/src/LNMMathPlugin.cc                                                                                                                                                                                      
| {standard input}: Assembler messages:                                                                                                                                                                                                       
| {standard input}:2270271: Warning: end of file not at end of a line; newline inserted                                                                                                                                                       
| {standard input}:2270659: Error: invalid address at operand 1 -- `b'                                                                                                                                                                        
| {standard input}: Error: open CFI at the end of file; missing .cfi_endproc directive                                                                                                                                                        
| aarch64-xilinx-linux-g++: fatal error: Killed signal terminated program cc1plus                                                                                                                                                             
| compilation terminated.                                                                       
```