### PR TITLE
fix: correct Python bindings CMake paths

### DIFF
--- a/recipes-deviceaccess/deviceaccess-python-bindings/deviceaccess-python-bindings_04.02.01.bb
+++ b/recipes-deviceaccess/deviceaccess-python-bindings/deviceaccess-python-bindings_04.02.01.bb
@@ -21,5 +21,7 @@ RDEPENDS:${PN} = "python3-numpy python3-core"
 inherit cmake pkgconfig python3-dir setuptools3-base
 
 # Specify any options you want to pass to cmake using EXTRA_OECMAKE:
-EXTRA_OECMAKE = "-DNUMPY_INCLUDE_DIRS:PATH=${STAGING_DIR_HOST}/${PYTHON_SITEPACKAGES_DIR}/numpy/core/include"
-
+EXTRA_OECMAKE = " \
+    -DNUMPY_INCLUDE_DIRS:PATH=${STAGING_DIR_HOST}${PYTHON_SITEPACKAGES_DIR}/numpy/core/include \
+    -Dpybind11_DIR:PATH=${STAGING_DIR_HOST}${PYTHON_SITEPACKAGES_DIR}/pybind11/share/cmake/pybind11 \
+"


### PR DESCRIPTION
The deviceaccess-python-bindings recipe failed during CMake configuration because the staged pybind11 package was not found automatically.

This change updates EXTRA_OECMAKE to:

- Explicitly provide pybind11_DIR from the Yocto target sysroot.

This allows CMake to locate both NumPy headers and the pybind11 CMake configuration during the cross-build.